### PR TITLE
A couple of fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Or download using go: `go get github.com/nhost/golambda`
 
 ## Usage
 
-`golambda --source {golang_function_file}.go --output {output_zip_file}.zip`
+`golambda -source {golang_function_file}.go -output {output_zip_file}.zip`
 
 The output file can directly be deployed on AWS Lambda.

--- a/example/hello.go
+++ b/example/hello.go
@@ -34,6 +34,8 @@ type Body struct {
 //	Expected Output: `Nhost pays it's respects to Wahal, Mrinal!`
 
 func Handler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
 	body, _ := ioutil.ReadAll(r.Body)
 	var payload Body
 	json.Unmarshal(body, &payload)

--- a/proxy.go.tmpl
+++ b/proxy.go.tmpl
@@ -1,7 +1,7 @@
-//	
+//
 //	This is the template that will wrap your original
 //	Golang function into a lambda compatible one.
-//	
+//
 
 package main
 
@@ -34,7 +34,7 @@ func route(handler func(http.ResponseWriter, *http.Request)) func(ctx context.Co
 			req.Header.Add(k, v)
 		}
 
-		var q url.Values
+		q := make(url.Values)
 		for key, value := range request.QueryStringParameters {
 			q.Add(key, value)
 		}

--- a/proxy.go.tmpl
+++ b/proxy.go.tmpl
@@ -63,6 +63,8 @@ func route(handler func(http.ResponseWriter, *http.Request)) func(ctx context.Co
 			}, err
 		}
 
+		defer res.Body.Close()
+
 		responseHeaders["Access-Control-Allow-Origin"] = "*"
 		responseHeaders["Access-Control-Allow-Headers"] = "origin,Accept,Authorization,Content-Type"
 

--- a/utils.go
+++ b/utils.go
@@ -36,7 +36,7 @@ func copy(src, dst string) (int64, error) {
 }
 
 func cleanup(path string) {
-	if err := os.Remove(path); err != nil {
+	if err := os.RemoveAll(path); err != nil {
 		log.Println("Failed to remove: ", path)
 	}
 }


### PR DESCRIPTION
- added response body `Close` call
- allocate memory for `url.Values` (was crashing)
- fixed cleanup (failed if the directory wasn't empty)
- fixed `Usage` snippet in README